### PR TITLE
Update missing components in turbo ORM sample CR and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# orm
-Operator Resource Mapping
+# Operator Resource Mapping
+Operator Resource Mapping (ORM) is a mechanism to allow [Kubeturbo](https://github.com/turbonomic/kubeturbo) to manage resources in an Operator managed Kubernetes cluster, for example to vertically scale containers or horizontally scale pods.
+
+Here’re the steps to deploy it:
+1. Create ORM CRD to the target XL cluster:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/turbonomic/orm/master/config/crd/bases/turbo_operator_resource_mapping_crd.yaml
+```
+2. Create XL ORM CR to each tenant namespace in XL cluster:
+```
+kubectl -n turbonomic apply -f https://raw.githubusercontent.com/turbonomic/orm/master/config/samples/turbo_operator_resource_mapping_sample_cr.yaml
+```
+3. Rediscover Kubeturbo target from Turbonomic UI and NO need to restart the corresponding Kubeturbo pod in XL cluster. ORM CR will be successfully discovered when you see a log message from Kubeturbo like this:
+```
+I0806 14:08:56.506469       1 k8s_discovery_client.go:271] Discovered 1 Operator managed Custom Resources in cluster Kubernetes-Turbonomic.
+```

--- a/config/samples/turbo_operator_resource_mapping_sample_cr.yaml
+++ b/config/samples/turbo_operator_resource_mapping_sample_cr.yaml
@@ -19,9 +19,13 @@ spec:
           - history
           - intersight-integration
           - kafka
+          - kubeturbo
           - market
+          - mediation-acims
           - mediation-actionscript
+          - mediation-actionstream-kafka
           - mediation-aix
+          - mediation-apic
           - mediation-appdynamics
           - mediation-appinsights
           - mediation-aws
@@ -36,7 +40,6 @@ spec:
           - mediation-baremetal
           - mediation-cloudfoundry
           - mediation-compellent
-          - mediation-customdata
           - mediation-datadog
           - mediation-dynatrace
           - mediation-gcp
@@ -46,17 +49,21 @@ spec:
           - mediation-hpe3par
           - mediation-hyperflex
           - mediation-hyperv
+          - mediation-instana
           - mediation-intersight
           - mediation-intersighthyperflex
           - mediation-intersightucs
           - mediation-istio
+          - mediation-jvm
           - mediation-mssql
+          - mediation-mysql
           - mediation-netapp
           - mediation-netflow
           - mediation-newrelic
           - mediation-nutanix
           - mediation-oneview
           - mediation-openstack
+          - mediation-oracle
           - mediation-pivotal
           - mediation-pure
           - mediation-rhv
@@ -65,6 +72,7 @@ spec:
           - mediation-snmp
           - mediation-terraform
           - mediation-tetration
+          - mediation-tomcat
           - mediation-ucs
           - mediation-ucsdirector
           - mediation-udt


### PR DESCRIPTION
1. Update missing components in turbo_operator_resource_mapping_sample_cr.yaml.
2. Update README with the steps to deploy ORM CRD and ORM CR.