### PR TITLE
Change apiVersion from v1beta to v1

### DIFF
--- a/config/crd/bases/turbo_operator_resource_mapping_crd_v1.yaml
+++ b/config/crd/bases/turbo_operator_resource_mapping_crd_v1.yaml
@@ -9,8 +9,25 @@ spec:
     listKind: OperatorResourceMappingList
     plural: operatorresourcemappings
     singular: operatorresourcemapping
+    shortNames:
+    - orm
+    - orms
   scope: Namespaced
   versions:
     - name: v1alpha1
       served: true
       storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+              type: object
+            
+


### PR DESCRIPTION
PR Template
# Intent
To adapt to the new Kubernetes/OCP version

# Background
Starting from Kubernetes v1.22 ([Kubernetes API and Feature Removals In 1.22: Here’s What You Need To Know](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#api-changes) ) and OCP 4.9 ([Kubernetes API and Feature Removals In 1.22: Here’s What You Need To Know](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#api-changes) ), v1beta1 version for CRDs is removed and not supported anymore.

# Implementation
Change the `apiVersion` of the CRD and add the necessary description to follow the `openAPIV3Schema` syntax requirement.

# Test Done

## Case 1
**1. Create the CRD with the new v1 version yaml file**
```
k create -f turbo_operator_resource_mapping_crd_v1.yaml
```
**2. Recreate all of the old ORM CR**
```
[root@localvm ~]# k create -f oldcr.yaml 
operatorresourcemapping.turbonomic.com/authentications.operator.ibm.com created
operatorresourcemapping.turbonomic.com/certmanagers.operator.ibm.com created
operatorresourcemapping.turbonomic.com/clusterserviceversions.operators.coreos.com created
operatorresourcemapping.turbonomic.com/grafanas.operator.ibm.com created
operatorresourcemapping.turbonomic.com/mongodbs.operator.ibm.com created
operatorresourcemapping.turbonomic.com/paps.operator.ibm.com created
operatorresourcemapping.turbonomic.com/policydecisions.operator.ibm.com created
```
![image](https://user-images.githubusercontent.com/61252360/162836555-455833d1-bdbd-4890-a2ec-8d5ca9b1011e.png)

**3. Test resizing action on the auth-pdp which is managed by the CR example-policydecision with the kind policydecisions.operator.ibm.com and then check the result**

![image](https://user-images.githubusercontent.com/61252360/162836617-8a9edcc7-60d7-4828-9c74-6b6ef3027d0d.png)







