### PR TITLE
fix build push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,11 @@
 # Build the manager binary
-FROM golang:1.19 as builder
-ARG TARGETOS
-ARG TARGETARCH
-
+FROM --platform=${BUILDPLATFORM} golang:1.20.3 as builder
+ARG TARGETOS TARGETARCH
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY . ./
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/Makefile
+++ b/Makefile
@@ -158,8 +158,9 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${REPOS}${IMG}:{TAG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${REPOS}${IMG}:${TAG}
+	- [ -z "$(PULL_SECRET)" ] && $(KUSTOMIZE) build config/default | kubectl apply -f -
+	- [ -n "$(PULL_SECRET)" ] && $(KUSTOMIZE) build config/default | sed -e "s|imagePullSecrets: \[\]|imagePullSecrets: \[{'name':'${PULL_SECRET}'}\]|" | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${REPO}${IMG}:{TAG}
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${REPOS}${IMG}:{TAG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,12 +65,14 @@ spec:
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         # seccompProfile:
         #   type: RuntimeDefault
+      imagePullSecrets: []
       containers:
       - command:
         - /manager
         args:
         - --leader-elect
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
After the changes here, I can run
```shell
 make REPO=docker-na.artifactory.swg-devops.com/hyc-turbo-internal-team-docker-local/turbonomic/tamer TAG=0.1 docker-buildx
```
![image](https://user-images.githubusercontent.com/124801688/232673850-9b5755cf-ee1a-47f9-a861-7681da00b021.png)


to use the image
```shell
make REPO=docker-na.artifactory.swg-devops.com/hyc-turbo-internal-team-docker-local/turbonomic/tamer TAG=0.1 PULL_SECRET=jfrogcred deploy

kubectl config set-context --current --namespace orm-system

kubectl create secret docker-registry jfrogcred --docker-server=docker-na.artifactory.swg-devops.com --docker-username=tamer.mohamed@ibm.com --docker-password=cmUlk --docker-email=tamer.mohamed@ibm.com

kubectl delete pods -l control-plane=controller-manager
```