### PR TITLE
error message for no owned resource; patterns should not overwritten …

### DIFF
--- a/registry/orm.go
+++ b/registry/orm.go
@@ -291,8 +291,10 @@ func (or *ResourceMappingRegistry) ValidateAndRegisterORM(orm *devopsv1alpha1.Op
 			}
 
 			if len(srcObjs) == 0 {
-				// add a fake pattern to generate error message
-				allpatterns = append(allpatterns, *p.DeepCopy())
+				// add a fake pattern to generate error message, use name to carry label selector info
+				fakep := *p.DeepCopy()
+				fakep.OwnedResourcePath.ObjectReference.Name = p.OwnedResourcePath.ObjectLocator.LabelSelector.String()
+				allpatterns = append(allpatterns, fakep)
 				continue
 			}
 			for _, obj := range srcObjs {

--- a/test/patterns/orm.yaml
+++ b/test/patterns/orm.yaml
@@ -12,6 +12,7 @@ spec:
       my_selector:
         matchLabels:
           app: ormsource-patterns
+          id: "0001"
     parameters:
       ports:
       - "TCP"
@@ -22,4 +23,20 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         selector: my_selector
+        path: .spec.template.spec.containers[?(@.name=="{{.owned.name}}")].ports[?(@.protocol=="{{ports}}")].containerPort
+    - ownerPath: .spec.template.spec.containers[?(@.name=="{{.owned.name}}")].ports[?(@.protocol=="{{ports}}")].containerPort
+      owned:
+        apiVersion: apps/v1
+        kind: Deployment
+        matchLabels:
+          app: ormsource-patterns
+          id: "0002"
+        path: .spec.template.spec.containers[?(@.name=="{{.owned.name}}")].ports[?(@.protocol=="{{ports}}")].containerPort
+    - ownerPath: .spec.template.spec.containers[?(@.name=="{{.owned.name}}")].ports[?(@.protocol=="{{ports}}")].containerPort
+      owned:
+        apiVersion: apps/v1
+        kind: Deployment
+        matchLabels:
+          app: ormsource-patterns
+          id: "0003"
         path: .spec.template.spec.containers[?(@.name=="{{.owned.name}}")].ports[?(@.protocol=="{{ports}}")].containerPort

--- a/test/patterns/source-0001.yaml
+++ b/test/patterns/source-0001.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ormsource-patterns-0001
   labels:
     app: ormsource-patterns
+    id: "0001"
 spec:
   replicas: 1
   selector:

--- a/test/patterns/source-0002.yaml
+++ b/test/patterns/source-0002.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ormsource-patterns-0002
   labels:
     app: ormsource-patterns
+    id: "0002"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
…each other with same path; and change some public function to private in registry

Added test cases in patterns for cases:

- show error for label selector with `ID: 0003` 

```yaml
    - message: 'Failed to locate owned resource: &ObjectReference{Kind:Deployment,Namespace:default,Name:&LabelSelector{MatchLabels:map[string]string{app:
        ormsource-patterns,id: 0003,},MatchExpressions:[]LabelSelectorRequirement{},},UID:,APIVersion:apps/v1,ResourceVersion:,FieldPath:,}'
      ownerPath: '.spec.template.spec.containers[?(@.name=="&LabelSelector{MatchLabels:map[string]string{app:
        ormsource-patterns,id: 0003,},MatchExpressions:[]LabelSelectorRequirement{},}")].ports[?(@.protocol=="TCP")].containerPort'
      reason: OwnedResourceError
```

- show all paths defined with "same" owned path and owner path and different selector

```yaml
ownerPath: .spec.template.spec.containers[?(@.name=="{{.owned.name}}")].ports[?(@.protocol=="{{ports}}")].containerPort
    path: .spec.template.spec.containers[?(@.name=="{{.owned.name}}")].ports[?(@.protocol=="{{ports}}")].containerPort
```