### PR TITLE
[OM-100520]: Add ORMs for redis and kafka operator deployments.

### DIFF
--- a/config/samples/kafka/kafka-orm.yaml
+++ b/config/samples/kafka/kafka-orm.yaml
@@ -1,0 +1,22 @@
+apiVersion: devops.turbonomic.io/v1alpha1
+kind: OperatorResourceMapping
+metadata:
+  name: strimzi-kafka-solo
+spec:
+  owner: # target same namespace by default
+    apiVersion: kafka.strimzi.io/v1beta2
+    kind: Kafka
+    name: my-cluster
+  mappings:
+    parameters:
+      containers:
+      - kafka
+    patterns:
+    - ownerPath: .spec.{{containers}}.resources       
+      owned:
+        apiVersion: v1
+        kind: Pod
+        matchLabels:
+          strimzi.io/controller: strimzipodset
+          strimzi.io/cluster: my-cluster
+        path: .spec.containers[?(@.name=="{{containers}}")].resources

--- a/config/samples/redis-standalone/redis-orm.yaml
+++ b/config/samples/redis-standalone/redis-orm.yaml
@@ -1,0 +1,23 @@
+apiVersion: devops.turbonomic.io/v1alpha1
+kind: OperatorResourceMapping
+metadata:
+  annotations:
+  name: redis-orm
+  namespace: ot-operators
+spec:
+  mappings:
+    parameters:
+      containers:
+      - redis
+    patterns:
+    - owned:
+        apiVersion: apps/v1
+        kind: StatefulSet
+        matchLabels:
+          app: redis
+        path: .spec.template.spec.containers[?(@.name=="{{containers}}")].resources
+      ownerPath: .spec.kubernetesConfig.resources
+  owner:
+    apiVersion: redis.redis.opstreelabs.in/v1beta1
+    kind: Redis
+    name: redis


### PR DESCRIPTION
Added ORMS for Redis and Kafka Operators.

Created a ORM for a stand alone Redis cluster operator from [OT_CONTAINER-KIT](https://github.com/OT-CONTAINER-KIT/redis-operator#quickstart). 

Created a ORM for KAfka operator from [strimzi-kafka-operator](https://github.com/strimzi/strimzi-kafka-operator).
