### PR TITLE
Omitted path support

### DIFF
--- a/api/v1alpha1/operatorresourcemapping_types.go
+++ b/api/v1alpha1/operatorresourcemapping_types.go
@@ -25,6 +25,16 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+var (
+	ANNOTATION_GROUP = "devops.turbonomic.io"
+
+	ANNOTATIONKEY_VALIDATE_OWNER_PATH = ANNOTATION_GROUP + "/validate-owner-path" // default: enabled
+	ANNOTATIONKEY_VALIDATE_OWNED_PATH = ANNOTATION_GROUP + "/validate-owned-path" // default: enabled
+
+	ANNOTATIONVALUE_ENABLED  = "enabled"
+	ANNOTATIONVALUE_DISABLED = "disabled"
+)
+
 // Reference to object by name or by label
 type ObjectLocator struct {
 	// if namespace is empty, use the owner's namespace as default;
@@ -91,7 +101,7 @@ type OwnerMappingValue struct {
 
 	// The reason for the condition's last transition.
 	// +optional
-	Reason string `json:"reason,omitempty"`
+	Reason ORMStatusReason `json:"reason,omitempty"`
 	// A human readable message indicating details about the transition.
 	// +optional
 	Message string `json:"message,omitempty"`
@@ -100,6 +110,7 @@ type OwnerMappingValue struct {
 type ORMStatusType string
 
 const (
+	ORMEmpty     ORMStatusType = ""
 	ORMTypeOK    ORMStatusType = "ok"
 	ORMTypeError ORMStatusType = "error"
 )
@@ -120,7 +131,7 @@ type OperatorResourceMappingStatus struct {
 	// state of ORM resource
 	State ORMStatusType `json:"state,omitempty"`
 	// +optional
-	Reason string `json:"reason,omitempty"`
+	Reason ORMStatusReason `json:"reason,omitempty"`
 	// A human readable message indicating details about the transition.
 	// +optional
 	Message string `json:"message,omitempty"`

--- a/controllers/advicemapping_controller.go
+++ b/controllers/advicemapping_controller.go
@@ -144,7 +144,7 @@ func (e *AdviceMappingReconciler) compareAndEnforce(am *devopsv1alpha1.AdviceMap
 
 		fields := strings.Split(m.Owner.Path, ".")
 		lastField := fields[len(fields)-1]
-		valueInOwner, found, err := ormutils.NestedField(obj, lastField, m.Owner.Path)
+		valueInOwner, found, err := ormutils.NestedField(obj.Object, lastField, m.Owner.Path)
 		if err != nil {
 			acLog.Error(err, "finding path in owner", "path", m.Owner.Path)
 			continue

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -141,7 +141,7 @@ var _ = BeforeSuite(func() {
 	k8sClient = k8sManager.GetClient()
 	Expect(k8sClient).NotTo(BeNil())
 
-	err = kubernetes.InitToolbox(k8sManager.GetConfig(), k8sManager.GetScheme())
+	err = kubernetes.InitToolbox(k8sManager.GetConfig(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("test"))
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&OperatorResourceMappingReconciler{

--- a/kubernetes/event.go
+++ b/kubernetes/event.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (e *ToolboxType) RecordEventf(obj runtime.Object, etype string, reason string, messageFmt string, args ...interface{}) {
+	if e.EventRecorder != nil {
+		e.Eventf(obj, etype, reason, messageFmt, args...)
+	}
+}
+
+func (e *ToolboxType) RecordEvent(obj runtime.Object, etype string, reason string, message string) {
+	if e.EventRecorder != nil {
+		e.Event(obj, etype, reason, message)
+	}
+}

--- a/kubernetes/init.go
+++ b/kubernetes/init.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,6 +37,7 @@ type ToolboxType struct {
 	Schema
 	Client
 	InformerFactory
+	record.EventRecorder
 }
 
 var (
@@ -49,11 +51,13 @@ func (r *ToolboxType) Start(ctx context.Context) {
 	r.InformerFactory.Start(r.ctx.Done())
 }
 
-func InitToolbox(config *rest.Config, scheme *runtime.Scheme) error {
+func InitToolbox(config *rest.Config, scheme *runtime.Scheme, rec record.EventRecorder) error {
 	var err error
 
 	if Toolbox == nil {
-		Toolbox = &ToolboxType{}
+		Toolbox = &ToolboxType{
+			EventRecorder: rec,
+		}
 	}
 
 	Toolbox.cfg = config

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = kubernetes.InitToolbox(mgr.GetConfig(), mgr.GetScheme())
+	err = kubernetes.InitToolbox(mgr.GetConfig(), mgr.GetScheme(), mgr.GetEventRecorderFor("ORM"))
 	if err != nil {
 		setupLog.Error(err, "unable to init kubernetes toolbox")
 		os.Exit(1)

--- a/registry/am.go
+++ b/registry/am.go
@@ -57,6 +57,6 @@ func (or *ResourceMappingRegistry) RegisterAM(am *devopsv1alpha1.AdviceMapping) 
 	return err
 }
 
-func (or *ResourceMappingRegistry) RetrieveAMEntryForAdvisor(advisor corev1.ObjectReference) ResourceMappingEntry {
+func (or *ResourceMappingRegistry) RetrieveAMEntryForAdvisor(advisor corev1.ObjectReference) ResourceMappingEntryType {
 	return retrieveResourceMappingEntryForObjectFromRegistry(or.advisorRegistry, advisor)
 }

--- a/registry/orm.go
+++ b/registry/orm.go
@@ -34,7 +34,6 @@ import (
 )
 
 var (
-	messagePlaceHolder                 = "owner path located"
 	errorMessageMultipleSourceForOwner = "allow 1 and only 1 input from owned.name, owned.selector, owner.labelSelector"
 	errorMessageUnknownSelector        = "unknown selector"
 )
@@ -120,7 +119,7 @@ func (or *ResourceMappingRegistry) SetORMStatusForOwner(owner *unstructured.Unst
 	if orm != nil && !or.staticCheckORMSpec(orm) {
 		err = kubernetes.Toolbox.OrmClient.Status().Update(context.TODO(), orm)
 		if err != nil {
-			rLog.Error(err, "retry status")
+			rLog.Error(err, "static check failed")
 		}
 		return
 	}
@@ -130,21 +129,30 @@ func (or *ResourceMappingRegistry) SetORMStatusForOwner(owner *unstructured.Unst
 	objref.Namespace = owner.GetNamespace()
 	objref.SetGroupVersionKind(owner.GetObjectKind().GroupVersionKind())
 
+	if orm != nil {
+		or.setORMStatus(owner, orm)
+		err = kubernetes.Toolbox.OrmClient.Status().Update(context.TODO(), orm)
+		if err != nil {
+			rLog.Error(err, "updating orm status")
+		}
+		return
+	}
+
 	ormEntry := or.retrieveORMEntryForOwner(objref)
 	// orm and owner are 1-1 mapping, ormEntry should be 1 only
 	for ormk := range ormEntry {
 
-		if orm == nil {
-			orm = &devopsv1alpha1.OperatorResourceMapping{}
-			err = kubernetes.Toolbox.OrmClient.Get(context.TODO(), ormk, orm)
-			if err != nil {
-				rLog.Error(err, "retrieving ", "orm", ormk)
-			}
+		orm = &devopsv1alpha1.OperatorResourceMapping{}
+		err = kubernetes.Toolbox.OrmClient.Get(context.TODO(), ormk, orm)
+		if err != nil {
+			rLog.Error(err, "retrieving ", "orm", ormk)
 		}
+
 		or.setORMStatus(owner, orm)
+
 		err = kubernetes.Toolbox.OrmClient.Status().Update(context.TODO(), orm)
 		if err != nil {
-			rLog.Error(err, "retry status")
+			rLog.Error(err, "updating orm status")
 		}
 	}
 }
@@ -179,14 +187,22 @@ func (or *ResourceMappingRegistry) staticCheckPattern(p *devopsv1alpha1.Pattern,
 func (or *ResourceMappingRegistry) staticCheckORMSpec(orm *devopsv1alpha1.OperatorResourceMapping) bool {
 	var passed = true
 
+	if !validateOwnerPathEnabled(orm) {
+		orm.Status.Message += "owner path validation is disabled;"
+	}
+
+	if !validateOwnedPathEnabled(orm) {
+		orm.Status.Message += "owned resource path validation is disabled;"
+	}
+
 	errMappingValues := []devopsv1alpha1.OwnerMappingValue{}
-	// only allow 1 way to choose target
+	// only allow 1 way to choose owner
 	for _, p := range orm.Spec.Mappings.Patterns {
 		if err := or.staticCheckPattern(&p, orm.Spec.Mappings.Selectors, orm.Spec.Mappings.Parameters); err != nil {
 			mv := devopsv1alpha1.OwnerMappingValue{
 				OwnerPath:         p.OwnerPath,
 				OwnedResourcePath: &p.OwnedResourcePath,
-				Reason:            string(devopsv1alpha1.ORMStatusReasonOwnedResourceError),
+				Reason:            devopsv1alpha1.ORMStatusReasonOwnedResourceError,
 				Message:           err.Error(),
 			}
 			errMappingValues = append(errMappingValues, mv)
@@ -203,7 +219,7 @@ func (or *ResourceMappingRegistry) staticCheckORMSpec(orm *devopsv1alpha1.Operat
 }
 
 func (or *ResourceMappingRegistry) setORMStatus(owner *unstructured.Unstructured, orm *devopsv1alpha1.OperatorResourceMapping) {
-
+	var err error
 	// set owner info and clean previous error status at status top level
 	orm.Status = devopsv1alpha1.OperatorResourceMappingStatus{}
 
@@ -228,18 +244,64 @@ func (or *ResourceMappingRegistry) setORMStatus(owner *unstructured.Unstructured
 		Name:      orm.GetName(),
 	})
 
-	for o, mappings := range *oe {
-		for op, sp := range mappings {
-			owned := devopsv1alpha1.OwnedResourcePath{
-				Path: sp,
+	for ownedref, mappings := range *oe {
+		ownedobj := &unstructured.Unstructured{}
+		ownedobj.SetGroupVersionKind(ownedref.GroupVersionKind())
+
+		ownedobj, err = kubernetes.Toolbox.GetResourceWithGVK(ownedref.GroupVersionKind(),
+			types.NamespacedName{Namespace: ownedref.Namespace, Name: ownedref.Name})
+		// failed to locate owned resource, set error to all paths
+		if err != nil {
+			for op := range mappings {
+				omv := devopsv1alpha1.OwnerMappingValue{
+					OwnerPath: op,
+					Message:   "Failed to locate owned resource: " + ownedref.String(),
+					Reason:    devopsv1alpha1.ORMStatusReasonOwnedResourceError,
+				}
+				orm.Status.OwnerMappingValues = append(orm.Status.OwnerMappingValues, omv)
 			}
-			owned.ObjectReference = o
-			mapitem := PrepareMappingForObject(owner, op, &owned)
-			orm.Status.OwnerMappingValues = append(orm.Status.OwnerMappingValues, *mapitem)
+			continue
+		}
+
+		for op, sp := range mappings {
+			omv := devopsv1alpha1.OwnerMappingValue{
+				OwnerPath: op,
+				OwnedResourcePath: &devopsv1alpha1.OwnedResourcePath{
+					ObjectLocator: devopsv1alpha1.ObjectLocator{
+						ObjectReference: ownedref,
+					},
+					Path: sp,
+				},
+				Value: ormutils.PrepareRawExtensionFromUnstructured(owner, op),
+			}
+
+			hide := false
+			if omv.Value == nil {
+				omv.Message = "Failed to locate ownerPath " + op
+				omv.Reason = devopsv1alpha1.ORMStatusReasonOwnerError
+				if validateOwnerPathEnabled(orm) {
+					orm.Status.OwnerMappingValues = append(orm.Status.OwnerMappingValues, omv)
+					continue
+				}
+				hide = true
+			}
+
+			testValue := ormutils.PrepareRawExtensionFromUnstructured(ownedobj, sp)
+			if testValue == nil {
+				omv.Message = "Failed to locate owned resource path " + sp
+				omv.Reason = devopsv1alpha1.ORMStatusReasonOwnedResourceError
+				if validateOwnedPathEnabled(orm) {
+					orm.Status.OwnerMappingValues = append(orm.Status.OwnerMappingValues, omv)
+					continue
+				}
+				hide = true
+			}
+
+			if !hide {
+				orm.Status.OwnerMappingValues = append(orm.Status.OwnerMappingValues, omv)
+			}
 		}
 	}
-
-	or.validateOwnedResources(owner, orm)
 
 	orm.Status.LastTransitionTime = &metav1.Time{
 		Time: time.Now(),
@@ -292,9 +354,9 @@ func (or *ResourceMappingRegistry) ValidateAndRegisterORM(orm *devopsv1alpha1.Op
 
 			if len(srcObjs) == 0 {
 				// add a fake pattern to generate error message, use name to carry label selector info
-				fakep := *p.DeepCopy()
-				fakep.OwnedResourcePath.ObjectReference.Name = p.OwnedResourcePath.ObjectLocator.LabelSelector.String()
-				allpatterns = append(allpatterns, fakep)
+				fakePattern := *p.DeepCopy()
+				fakePattern.OwnedResourcePath.ObjectReference.Name = p.OwnedResourcePath.ObjectLocator.LabelSelector.String()
+				allpatterns = append(allpatterns, fakePattern)
 				continue
 			}
 			for _, obj := range srcObjs {
@@ -380,76 +442,40 @@ func populatePatterns(parameters map[string][]string, pattern devopsv1alpha1.Pat
 	return allpatterns
 }
 
-func (or *ResourceMappingRegistry) validateOwnedResources(owner *unstructured.Unstructured, orm *devopsv1alpha1.OperatorResourceMapping) {
-	var err error
-
-	ownerRef := corev1.ObjectReference{
-		Namespace: owner.GetNamespace(),
-		Name:      owner.GetName(),
-	}
-	ownerRef.SetGroupVersionKind(owner.GetObjectKind().GroupVersionKind())
-
-	oe := or.retrieveObjectEntryForOwnerAndORM(ownerRef, types.NamespacedName{
-		Namespace: orm.GetNamespace(),
-		Name:      orm.GetName(),
-	})
-
-	if oe == nil {
-		rLog.Error(errors.New("failed to locate owner in registry"), "owner ref", ownerRef, "orm", orm)
-		return
+// ValidateOwnedPathEnabled checks if the annotation is set to "disabled", otherwise it is enabled
+func validateOwnedPathEnabled(orm *devopsv1alpha1.OperatorResourceMapping) bool {
+	if orm == nil {
+		return true
 	}
 
-	for resource, mappings := range *oe {
-		resobj := &unstructured.Unstructured{}
-		resobj.SetGroupVersionKind(resource.GroupVersionKind())
-
-		resobj, err = kubernetes.Toolbox.GetResourceWithGVK(resource.GroupVersionKind(), types.NamespacedName{Namespace: resource.Namespace, Name: resource.Name})
-		if err != nil {
-			for op := range mappings {
-				for n, m := range orm.Status.OwnerMappingValues {
-					if op == m.OwnerPath {
-						orm.Status.OwnerMappingValues[n].Message = "Failed to locate owned resource: " + resource.String()
-						orm.Status.OwnerMappingValues[n].Reason = string(devopsv1alpha1.ORMStatusReasonOwnedResourceError)
-					}
-				}
-			}
-			continue
-		}
-
-		for op, sp := range mappings {
-			testValue := ormutils.PrepareRawExtensionFromUnstructured(resobj, sp)
-			for n, m := range orm.Status.OwnerMappingValues {
-				if op == m.OwnerPath {
-					if testValue == nil && orm.Status.OwnerMappingValues[n].Message == messagePlaceHolder {
-						orm.Status.OwnerMappingValues[n].Message = "Failed to locate mapping path " + sp + " in owned resource"
-						orm.Status.OwnerMappingValues[n].Reason = string(devopsv1alpha1.ORMStatusReasonOwnedResourceError)
-					} else if testValue != nil && orm.Status.OwnerMappingValues[n].Message == messagePlaceHolder {
-						orm.Status.OwnerMappingValues[n].Message = ""
-						orm.Status.OwnerMappingValues[n].Reason = ""
-					} else if testValue != nil && orm.Status.OwnerMappingValues[n].Reason == string(devopsv1alpha1.ORMStatusReasonOwnedResourceError) {
-						orm.Status.OwnerMappingValues[n].Message = ""
-						orm.Status.OwnerMappingValues[n].Reason = ""
-					}
-				}
-			}
-		}
+	annotations := orm.GetAnnotations()
+	if annotations == nil {
+		return true
 	}
 
+	v, ok := annotations[devopsv1alpha1.ANNOTATIONKEY_VALIDATE_OWNED_PATH]
+	if ok && strings.EqualFold(v, devopsv1alpha1.ANNOTATIONVALUE_DISABLED) {
+		return false
+	}
+
+	return true
 }
 
-func PrepareMappingForObject(obj *unstructured.Unstructured, objPath string, owned *devopsv1alpha1.OwnedResourcePath) *devopsv1alpha1.OwnerMappingValue {
-	mapitem := devopsv1alpha1.OwnerMappingValue{}
-	mapitem.OwnerPath = objPath
-
-	mapitem.Value = ormutils.PrepareRawExtensionFromUnstructured(obj, objPath)
-	if mapitem.Value == nil {
-		mapitem.Message = "Failed to locate ownerPath in owner"
-		mapitem.Reason = string(devopsv1alpha1.ORMStatusReasonOwnerError)
-		return &mapitem
+// ValidateOwnedPathEnabled checks if the annotation is set to "disabled", otherwise it is enabled
+func validateOwnerPathEnabled(orm *devopsv1alpha1.OperatorResourceMapping) bool {
+	if orm == nil {
+		return true
 	}
 
-	mapitem.Message = messagePlaceHolder
-	mapitem.OwnedResourcePath = owned
+	annotations := orm.GetAnnotations()
+	if annotations == nil {
+		return true
+	}
 
-	return &mapitem
+	v, ok := annotations[devopsv1alpha1.ANNOTATIONKEY_VALIDATE_OWNER_PATH]
+	if ok && strings.EqualFold(v, devopsv1alpha1.ANNOTATIONVALUE_DISABLED) {
+		return false
+	}
+
+	return true
 }

--- a/registry/orm.go
+++ b/registry/orm.go
@@ -219,7 +219,6 @@ func (or *ResourceMappingRegistry) staticCheckORMSpec(orm *devopsv1alpha1.Operat
 }
 
 func (or *ResourceMappingRegistry) setORMStatus(owner *unstructured.Unstructured, orm *devopsv1alpha1.OperatorResourceMapping) {
-	var err error
 	// set owner info and clean previous error status at status top level
 	orm.Status = devopsv1alpha1.OperatorResourceMappingStatus{}
 
@@ -248,6 +247,7 @@ func (or *ResourceMappingRegistry) setORMStatus(owner *unstructured.Unstructured
 		ownedobj := &unstructured.Unstructured{}
 		ownedobj.SetGroupVersionKind(ownedref.GroupVersionKind())
 
+		var err error
 		ownedobj, err = kubernetes.Toolbox.GetResourceWithGVK(ownedref.GroupVersionKind(),
 			types.NamespacedName{Namespace: ownedref.Namespace, Name: ownedref.Name})
 		// failed to locate owned resource, set error to all paths
@@ -401,11 +401,11 @@ func (or *ResourceMappingRegistry) CleanupRegistryForORM(orm types.NamespacedNam
 	}
 }
 
-func (or *ResourceMappingRegistry) retrieveORMEntryForOwner(owner corev1.ObjectReference) ResourceMappingEntry {
+func (or *ResourceMappingRegistry) retrieveORMEntryForOwner(owner corev1.ObjectReference) ResourceMappingEntryType {
 	return retrieveResourceMappingEntryForObjectFromRegistry(or.ownerRegistry, owner)
 }
 
-func (or *ResourceMappingRegistry) retrieveORMEntryForOwned(owned corev1.ObjectReference) ResourceMappingEntry {
+func (or *ResourceMappingRegistry) retrieveORMEntryForOwned(owned corev1.ObjectReference) ResourceMappingEntryType {
 	return retrieveResourceMappingEntryForObjectFromRegistry(or.ownedRegistry, owned)
 }
 

--- a/registry/suite_test.go
+++ b/registry/suite_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Registry Test", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	registry := make(map[corev1.ObjectReference]ResourceMappingEntry)
+	registry := make(map[corev1.ObjectReference]ResourceMappingEntryType)
 	It("can register path", func() {
 		err := registerMappingToRegistry(registry, _t_ownerpath, _t_ownedpath, _t_ormkey, _t_ownerref, _t_ownedref)
 		Expect(err).NotTo(HaveOccurred())

--- a/registry/suite_test.go
+++ b/registry/suite_test.go
@@ -1,0 +1,309 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	devopsv1alpha1 "github.com/turbonomic/orm/api/v1alpha1"
+	"github.com/turbonomic/orm/kubernetes"
+)
+
+var (
+	cfg     *rest.Config
+	cli     client.Client
+	testEnv *envtest.Environment
+	ctx     context.Context
+	cancel  context.CancelFunc
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = devopsv1alpha1.AddToScheme(testEnv.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	cli, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = cli.Create(ctx, &_t_owner)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = cli.Create(ctx, &_t_owned)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = cli.Create(ctx, &_t_orm)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = cli.Create(ctx, &_t_ormWithOmitPath)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = cli.Create(ctx, &_t_ormMixed)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = kubernetes.InitToolbox(cfg, testEnv.Scheme)
+	Expect(err).ToNot(HaveOccurred())
+
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var (
+	rmr ResourceMappingRegistry
+)
+
+var _ = Describe("Registry Test", func() {
+
+	It("can detect empty registry when register ", func() {
+		err := registerMappingToRegistry(nil, _t_ownerpath, _t_ownedpath, _t_ormkey, _t_ownerref, _t_ownedref)
+		Expect(err).To(HaveOccurred())
+	})
+
+	registry := make(map[corev1.ObjectReference]ResourceMappingEntry)
+	It("can register path", func() {
+		err := registerMappingToRegistry(registry, _t_ownerpath, _t_ownedpath, _t_ormkey, _t_ownerref, _t_ownedref)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("can fetch the path registered", func() {
+		oe := retrieveObjectEntryForObjectAndORMFromRegistry(registry, _t_ownedref, _t_ormkey)
+		Expect(oe).NotTo(BeNil())
+		pmap, ok := (*oe)[_t_ownerref]
+		Expect(ok).To(BeTrue())
+		Expect(pmap).NotTo(BeNil())
+		v, ok := pmap[_t_ownerpath]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(BeEquivalentTo(_t_ownedpath))
+	})
+
+	It("can delete path", func() {
+		deleteMappingFromRegistry(registry, _t_ownerpath, _t_ownedpath, _t_ormkey, _t_ownerref, _t_ownedref)
+	})
+
+	It("can verify the deleted path is gone", func() {
+		oe := retrieveObjectEntryForObjectAndORMFromRegistry(registry, _t_ownedref, _t_ormkey)
+		Expect(oe).NotTo(BeNil())
+		pmap, ok := (*oe)[_t_ownerref]
+		Expect(ok).To(BeTrue())
+		Expect(pmap).NotTo(BeNil())
+		_, ok = pmap[_t_ownerpath]
+		Expect(ok).NotTo(BeTrue())
+	})
+})
+
+var _ = Describe("ORM Test", func() {
+
+	var ormobj *devopsv1alpha1.OperatorResourceMapping
+	var ownerobj *unstructured.Unstructured
+	var err error
+
+	It("can register orm", func() {
+		ormobj, ownerobj, err = rmr.ValidateAndRegisterORM(&_t_orm)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ownerobj).ToNot(BeNil())
+		Expect(ormobj).ToNot(BeNil())
+	})
+
+	It("can find the path registered by orm in owner registry", func() {
+		oe := retrieveObjectEntryForObjectAndORMFromRegistry(rmr.ownerRegistry, _t_ownerref, _t_ormkey)
+		Expect(oe).NotTo(BeNil())
+		pmap, ok := (*oe)[_t_ownedref]
+		Expect(ok).To(BeTrue())
+		Expect(pmap).NotTo(BeNil())
+		v, ok := pmap[_t_ownerpath]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(BeEquivalentTo(_t_ownedpath))
+	})
+
+	It("can find the path registered by orm in owned registry", func() {
+		oe := retrieveObjectEntryForObjectAndORMFromRegistry(rmr.ownedRegistry, _t_ownedref, _t_ormkey)
+		Expect(oe).NotTo(BeNil())
+		pmap, ok := (*oe)[_t_ownerref]
+		Expect(ok).To(BeTrue())
+		Expect(pmap).NotTo(BeNil())
+		v, ok := pmap[_t_ownedpath]
+		Expect(ok).To(BeTrue())
+		Expect(v).To(BeEquivalentTo(_t_ownerpath))
+	})
+
+	It("can generate status while all fields are valid", func() {
+		rmr.SetORMStatusForOwner(ownerobj, ormobj)
+		Expect(ormobj.Status.State).To(BeEquivalentTo(devopsv1alpha1.ORMTypeOK))
+		Expect(ormobj.Status.Owner).To(BeEquivalentTo(_t_ownerref))
+		Expect(ormobj.Status.OwnerMappingValues).NotTo(BeNil())
+		Expect(len(ormobj.Status.OwnerMappingValues)).To(BeEquivalentTo(1))
+		omv := ormobj.Status.OwnerMappingValues[0]
+		Expect(omv.Message).To(BeEmpty())
+		Expect(omv.Reason).To(BeEmpty())
+		Expect(omv.OwnedResourcePath.ObjectLocator.ObjectReference).To(BeEquivalentTo(_t_ownedref))
+		Expect(omv.OwnedResourcePath.Path).To(BeEquivalentTo(_t_ownedpath))
+		Expect(omv.OwnerPath).To(BeEquivalentTo(_t_ownerpath))
+		uv, err := runtime.DefaultUnstructuredConverter.ToUnstructured(omv.Value)
+		Expect(err).ToNot(HaveOccurred())
+		rv, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&_t_res1)
+		Expect(err).ToNot(HaveOccurred())
+		vk := _t_ownerpath[strings.LastIndex(_t_ownerpath, ".")+1:]
+		Expect(uv[vk]).To(BeEquivalentTo(rv))
+	})
+
+	It("can show error for orm with omitted path while validation is enabled (default)", func() {
+		ormobj, ownerobj, err = rmr.ValidateAndRegisterORM(&_t_ormWithOmitPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ownerobj).ToNot(BeNil())
+		Expect(ormobj).ToNot(BeNil())
+		rmr.SetORMStatusForOwner(ownerobj, ormobj)
+		Expect(ormobj.Status.State).To(BeEquivalentTo(devopsv1alpha1.ORMTypeOK))
+		Expect(ormobj.Status.Owner).To(BeEquivalentTo(_t_ownerref))
+		Expect(ormobj.Status.OwnerMappingValues).NotTo(BeNil())
+		Expect(len(ormobj.Status.OwnerMappingValues)).To(BeEquivalentTo(1))
+		omv := ormobj.Status.OwnerMappingValues[0]
+		Expect(omv.Message).NotTo(BeEmpty())
+		Expect(omv.Reason).To(BeEquivalentTo(devopsv1alpha1.ORMStatusReasonOwnerError))
+	})
+
+	It("can show owner path error while owned validation is disabled", func() {
+		ormobj, ownerobj, err = rmr.ValidateAndRegisterORM(&_t_ormWithOmitPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ownerobj).ToNot(BeNil())
+		Expect(ormobj).ToNot(BeNil())
+		ormobj.Annotations = map[string]string{
+			devopsv1alpha1.ANNOTATIONKEY_VALIDATE_OWNED_PATH: devopsv1alpha1.ANNOTATIONVALUE_DISABLED,
+		}
+		rmr.SetORMStatusForOwner(ownerobj, ormobj)
+		Expect(ormobj.Status.State).To(BeEquivalentTo(devopsv1alpha1.ORMTypeOK))
+		Expect(ormobj.Status.Owner).To(BeEquivalentTo(_t_ownerref))
+		Expect(len(ormobj.Status.OwnerMappingValues)).To(BeEquivalentTo(1))
+		omv := ormobj.Status.OwnerMappingValues[0]
+		Expect(omv.Message).NotTo(BeEmpty())
+		Expect(omv.Reason).To(BeEquivalentTo(devopsv1alpha1.ORMStatusReasonOwnerError))
+	})
+
+	It("can show owned resource path error while owner validation is disabled", func() {
+		ormobj, ownerobj, err = rmr.ValidateAndRegisterORM(&_t_ormWithOmitPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ownerobj).ToNot(BeNil())
+		Expect(ormobj).ToNot(BeNil())
+		ormobj.Annotations = map[string]string{
+			devopsv1alpha1.ANNOTATIONKEY_VALIDATE_OWNER_PATH: devopsv1alpha1.ANNOTATIONVALUE_DISABLED,
+		}
+		// manually fix owner path for testing
+		ormobj.Spec.Mappings.Patterns[0].OwnerPath = _t_ownerpath
+
+		rmr.SetORMStatusForOwner(ownerobj, ormobj)
+		Expect(ormobj.Status.State).To(BeEquivalentTo(devopsv1alpha1.ORMTypeOK))
+		Expect(ormobj.Status.Owner).To(BeEquivalentTo(_t_ownerref))
+		Expect(len(ormobj.Status.OwnerMappingValues)).To(BeEquivalentTo(1))
+		omv := ormobj.Status.OwnerMappingValues[0]
+		Expect(omv.Message).NotTo(BeEmpty())
+		Expect(omv.Reason).To(BeEquivalentTo(devopsv1alpha1.ORMStatusReasonOwnedResourceError))
+	})
+
+	It("does not show error nor mapping in status for orm with omitted path while validation is disabled", func() {
+		ormobj, ownerobj, err = rmr.ValidateAndRegisterORM(&_t_ormWithOmitPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ownerobj).ToNot(BeNil())
+		Expect(ormobj).ToNot(BeNil())
+		ormobj.Annotations = map[string]string{
+			devopsv1alpha1.ANNOTATIONKEY_VALIDATE_OWNED_PATH: devopsv1alpha1.ANNOTATIONVALUE_DISABLED,
+			devopsv1alpha1.ANNOTATIONKEY_VALIDATE_OWNER_PATH: devopsv1alpha1.ANNOTATIONVALUE_DISABLED,
+		}
+		rmr.SetORMStatusForOwner(ownerobj, ormobj)
+		Expect(ormobj.Status.State).To(BeEquivalentTo(devopsv1alpha1.ORMTypeOK))
+		Expect(ormobj.Status.Owner).To(BeEquivalentTo(_t_ownerref))
+		Expect(len(ormobj.Status.OwnerMappingValues)).To(BeEquivalentTo(0))
+	})
+
+	It("can show error for orm with mixed good and bad patterns while validation is enabled (default)", func() {
+		ormobj, ownerobj, err = rmr.ValidateAndRegisterORM(&_t_ormMixed)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ownerobj).ToNot(BeNil())
+		Expect(ormobj).ToNot(BeNil())
+
+		// enable validation
+		rmr.SetORMStatusForOwner(ownerobj, ormobj)
+		Expect(ormobj.Status.State).To(BeEquivalentTo(devopsv1alpha1.ORMTypeOK))
+		Expect(ormobj.Status.Owner).To(BeEquivalentTo(_t_ownerref))
+		Expect(ormobj.Status.OwnerMappingValues).NotTo(BeNil())
+		Expect(len(ormobj.Status.OwnerMappingValues)).To(BeEquivalentTo(2))
+
+		//assuming 0 is good, 1 is bad based on order in patterns, might be wrong
+		omv := ormobj.Status.OwnerMappingValues[0]
+		Expect(omv.Message).NotTo(BeEmpty())
+		Expect(omv.Reason).NotTo(BeEmpty())
+		omv = ormobj.Status.OwnerMappingValues[1]
+		Expect(omv.Message).To(BeEmpty())
+		Expect(omv.Reason).To(BeEmpty())
+	})
+
+	It("can hide error with mixed good and bad patterns while validation is disabled", func() {
+		ormobj, ownerobj, err = rmr.ValidateAndRegisterORM(&_t_ormMixed)
+
+		// disable validation
+		ormobj.Annotations = map[string]string{
+			devopsv1alpha1.ANNOTATIONKEY_VALIDATE_OWNED_PATH: devopsv1alpha1.ANNOTATIONVALUE_DISABLED,
+			devopsv1alpha1.ANNOTATIONKEY_VALIDATE_OWNER_PATH: devopsv1alpha1.ANNOTATIONVALUE_DISABLED,
+		}
+		rmr.SetORMStatusForOwner(ownerobj, ormobj)
+		Expect(ormobj.Status.State).To(BeEquivalentTo(devopsv1alpha1.ORMTypeOK))
+		Expect(ormobj.Status.Owner).To(BeEquivalentTo(_t_ownerref))
+		Expect(len(ormobj.Status.OwnerMappingValues)).To(BeEquivalentTo(1))
+		omv := ormobj.Status.OwnerMappingValues[0]
+		Expect(omv.Message).To(BeEmpty())
+		Expect(omv.Reason).To(BeEmpty())
+
+	})
+})
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Utils Suite")
+}

--- a/registry/suite_test.go
+++ b/registry/suite_test.go
@@ -84,7 +84,7 @@ var _ = BeforeSuite(func() {
 	err = cli.Create(ctx, &_t_ormMixed)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = kubernetes.InitToolbox(cfg, testEnv.Scheme)
+	err = kubernetes.InitToolbox(cfg, testEnv.Scheme, nil)
 	Expect(err).ToNot(HaveOccurred())
 
 })
@@ -274,11 +274,15 @@ var _ = Describe("ORM Test", func() {
 		Expect(ormobj.Status.OwnerMappingValues).NotTo(BeNil())
 		Expect(len(ormobj.Status.OwnerMappingValues)).To(BeEquivalentTo(2))
 
-		//assuming 0 is good, 1 is bad based on order in patterns, might be wrong
-		omv := ormobj.Status.OwnerMappingValues[0]
+		//there must be 1 good and 1 bad mapping
+		n := 0
+		if ormobj.Status.OwnerMappingValues[0].Message == "" {
+			n = 1 - n
+		}
+		omv := ormobj.Status.OwnerMappingValues[n]
 		Expect(omv.Message).NotTo(BeEmpty())
 		Expect(omv.Reason).NotTo(BeEmpty())
-		omv = ormobj.Status.OwnerMappingValues[1]
+		omv = ormobj.Status.OwnerMappingValues[1-n]
 		Expect(omv.Message).To(BeEmpty())
 		Expect(omv.Reason).To(BeEmpty())
 	})

--- a/registry/suite_test_resources.go
+++ b/registry/suite_test_resources.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	devopsv1alpha1 "github.com/turbonomic/orm/api/v1alpha1"
+)
+
+var (
+	_t_ownerpath = ".spec.template.spec.containers[?(@.name==\"" + _t_ownerref.Name + "\")].resources"
+	_t_ownedpath = ".spec.template.spec.containers[?(@.name==\"" + _t_ownedref.Name + "\")].resources"
+	_t_ormkey    = types.NamespacedName{
+		Namespace: "default",
+		Name:      "orm",
+	}
+	_t_ownerref = corev1.ObjectReference{
+		Namespace:  "default",
+		Name:       "owner",
+		Kind:       "Deployment",
+		APIVersion: "apps/v1",
+	}
+	_t_ownedref = corev1.ObjectReference{
+		Namespace:  "default",
+		Name:       "owned",
+		Kind:       "Deployment",
+		APIVersion: "apps/v1",
+	}
+
+	_t_image = "test-image"
+
+	_t_res1 = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"cpu": *resource.NewMilliQuantity(1000, resource.DecimalSI),
+		},
+	}
+	_t_res2 = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"cpu": *resource.NewMilliQuantity(2000, resource.DecimalSI),
+		},
+	}
+
+	_t_owner = appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      _t_ownerref.Name,
+			Namespace: _t_ownerref.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": _t_ownerref.Name,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name": _t_ownerref.Name,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:      _t_ownerref.Name,
+							Image:     _t_image,
+							Resources: _t_res1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_t_owned = appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      _t_ownedref.Name,
+			Namespace: _t_ownerref.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": _t_ownedref.Name,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name": _t_ownedref.Name,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:      _t_ownedref.Name,
+							Image:     _t_image,
+							Resources: _t_res2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_t_orm = devopsv1alpha1.OperatorResourceMapping{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      _t_ormkey.Name,
+			Namespace: _t_ormkey.Namespace,
+		},
+		Spec: devopsv1alpha1.OperatorResourceMappingSpec{
+			Owner: devopsv1alpha1.ObjectLocator{
+				ObjectReference: _t_ownerref,
+			},
+			Mappings: devopsv1alpha1.MappingPatterns{
+				Patterns: []devopsv1alpha1.Pattern{
+					{
+						OwnerPath: _t_ownerpath,
+						OwnedResourcePath: devopsv1alpha1.OwnedResourcePath{
+							ObjectLocator: devopsv1alpha1.ObjectLocator{
+								ObjectReference: _t_ownedref,
+							},
+							Path: _t_ownedpath,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_t_ownedOmitPath = ".spec.template.spec.containers[?(@.name==\"" + _t_ownerref.Name + "\")].ports[?(@.protocol==\"TCP\")].containerPort"
+	_t_ownerOmitPath = ".spec.template.spec.containers[?(@.name==\"" + _t_ownerref.Name + "\")].ports[?(@.protocol==\"TCP\")].containerPort"
+
+	_t_ormWitOmitPathKey = types.NamespacedName{
+		Name:      "ormomitpath",
+		Namespace: "default",
+	}
+	_t_ormWithOmitPath = devopsv1alpha1.OperatorResourceMapping{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      _t_ormWitOmitPathKey.Name,
+			Namespace: _t_ormWitOmitPathKey.Namespace,
+		},
+		Spec: devopsv1alpha1.OperatorResourceMappingSpec{
+			Owner: devopsv1alpha1.ObjectLocator{
+				ObjectReference: _t_ownerref,
+			},
+			Mappings: devopsv1alpha1.MappingPatterns{
+				Patterns: []devopsv1alpha1.Pattern{
+					{
+						OwnerPath: _t_ownerOmitPath,
+						OwnedResourcePath: devopsv1alpha1.OwnedResourcePath{
+							ObjectLocator: devopsv1alpha1.ObjectLocator{
+								ObjectReference: _t_ownedref,
+							},
+							Path: _t_ownedOmitPath,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_t_ormMixedKey = types.NamespacedName{
+		Name:      "ormmixed",
+		Namespace: "default",
+	}
+	_t_ormMixed = devopsv1alpha1.OperatorResourceMapping{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      _t_ormMixedKey.Name,
+			Namespace: _t_ormMixedKey.Namespace,
+		},
+		Spec: devopsv1alpha1.OperatorResourceMappingSpec{
+			Owner: devopsv1alpha1.ObjectLocator{
+				ObjectReference: _t_ownerref,
+			},
+			Mappings: devopsv1alpha1.MappingPatterns{
+				Patterns: []devopsv1alpha1.Pattern{
+					{
+						OwnerPath: _t_ownerOmitPath,
+						OwnedResourcePath: devopsv1alpha1.OwnedResourcePath{
+							ObjectLocator: devopsv1alpha1.ObjectLocator{
+								ObjectReference: _t_ownedref,
+							},
+							Path: _t_ownedOmitPath,
+						},
+					},
+					{
+						OwnerPath: _t_ownerpath,
+						OwnedResourcePath: devopsv1alpha1.OwnedResourcePath{
+							ObjectLocator: devopsv1alpha1.ObjectLocator{
+								ObjectReference: _t_ownedref,
+							},
+							Path: _t_ownedpath,
+						},
+					},
+				},
+			},
+		},
+	}
+)

--- a/utils/suite_test.go
+++ b/utils/suite_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Set Nested_Field", func() {
 	})
 
 	It("can get value from omitted path just created", func() {
-		v, found, err := NestedField(obj.Object, "resources", pathSimple)
+		v, found, err := NestedField(obj.Object, pathSimple)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
 		Expect(v).To(BeEquivalentTo(resourceValue1))
@@ -72,7 +72,7 @@ var _ = Describe("Set Nested_Field", func() {
 	})
 
 	It("can get value from existing path just created", func() {
-		v, found, err := NestedField(obj.Object, "resources", pathSimple)
+		v, found, err := NestedField(obj.Object, pathSimple)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
 		Expect(v).To(BeEquivalentTo(resourceValue2))
@@ -90,7 +90,7 @@ var _ = Describe("Set Nested_Field With Slice Filter", func() {
 	})
 
 	It("can get value from omitted path with filter just created", func() {
-		v, found, err := NestedField(obj.Object, "resources", pathWithFilter)
+		v, found, err := NestedField(obj.Object, pathWithFilter)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
 		Expect(v).To(BeEquivalentTo(resourceValue1))
@@ -102,7 +102,7 @@ var _ = Describe("Set Nested_Field With Slice Filter", func() {
 	})
 
 	It("can get value from existing path with filter just created", func() {
-		v, found, err := NestedField(obj.Object, "resources", pathWithFilter)
+		v, found, err := NestedField(obj.Object, pathWithFilter)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
 		Expect(v).To(BeEquivalentTo(resourceValue2))
@@ -114,14 +114,14 @@ var _ = Describe("Set Nested_Field With Slice Filter", func() {
 	})
 
 	It("can get value from partially existing path with filter just created", func() {
-		v, found, err := NestedField(obj.Object, "resources", pathWithFilter2)
+		v, found, err := NestedField(obj.Object, pathWithFilter2)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
 		Expect(v).To(BeEquivalentTo(resourceValue1))
 	})
 
 	It("does not impact value from existing path with filter created before", func() {
-		v, found, err := NestedField(obj.Object, "resources", pathWithFilter)
+		v, found, err := NestedField(obj.Object, pathWithFilter)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
 		Expect(v).To(BeEquivalentTo(resourceValue2))

--- a/utils/suite_test.go
+++ b/utils/suite_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Utils Suite")
+}
+
+var (
+	pathSimple      = ".spec.template.spec.container.resources"
+	pathWithFilter  = ".spec.template.spec.containers[?(@.name==\"test\")].resources"
+	pathWithFilter2 = ".spec.template.spec.containers[?(@.name==\"another\")].resources"
+	resourceValue1  = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"cpu": *resource.NewMilliQuantity(1000, resource.DecimalSI),
+		},
+	}
+	resourceValue2 = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"cpu": *resource.NewMilliQuantity(2000, resource.DecimalSI),
+		},
+	}
+)
+
+var _ = Describe("Set Nested_Field", func() {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("group/v1")
+	obj.SetKind("Kind")
+
+	It("can create omitted path and fill value", func() {
+		err := SetNestedField(obj.Object, resourceValue1, pathSimple)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("can get value from omitted path just created", func() {
+		v, found, err := NestedField(obj.Object, "resources", pathSimple)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(v).To(BeEquivalentTo(resourceValue1))
+	})
+
+	It("work with existing path and fill value", func() {
+		err := SetNestedField(obj.Object, resourceValue2, pathSimple)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("can get value from existing path just created", func() {
+		v, found, err := NestedField(obj.Object, "resources", pathSimple)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(v).To(BeEquivalentTo(resourceValue2))
+	})
+})
+
+var _ = Describe("Set Nested_Field With Slice Filter", func() {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("group/v1")
+	obj.SetKind("Kind")
+
+	It("can create omitted path with slice filter and fill value", func() {
+		err := SetNestedField(obj.Object, resourceValue1, pathWithFilter)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("can get value from omitted path with filter just created", func() {
+		v, found, err := NestedField(obj.Object, "resources", pathWithFilter)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(v).To(BeEquivalentTo(resourceValue1))
+	})
+
+	It("can work with existing path with slice filter and fill value", func() {
+		err := SetNestedField(obj.Object, resourceValue2, pathWithFilter)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("can get value from existing path with filter just created", func() {
+		v, found, err := NestedField(obj.Object, "resources", pathWithFilter)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(v).To(BeEquivalentTo(resourceValue2))
+	})
+
+	It("can work with partially existing path with slice filter and fill value", func() {
+		err := SetNestedField(obj.Object, resourceValue1, pathWithFilter2)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("can get value from partially existing path with filter just created", func() {
+		v, found, err := NestedField(obj.Object, "resources", pathWithFilter2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(v).To(BeEquivalentTo(resourceValue1))
+	})
+
+	It("does not impact value from existing path with filter created before", func() {
+		v, found, err := NestedField(obj.Object, "resources", pathWithFilter)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(v).To(BeEquivalentTo(resourceValue2))
+	})
+})

--- a/utils/unstructured.go
+++ b/utils/unstructured.go
@@ -33,6 +33,11 @@ var (
 
 // NestedField returns the value of a nested field in the given object based on the given JSON-Path.
 func NestedField(obj interface{}, path string) (interface{}, bool, error) {
+
+	if obj == nil || path == "" {
+		return nil, false, nil
+	}
+
 	j := jsonpath.New(path).AllowMissingKeys(true)
 	template := fmt.Sprintf("{%s}", path)
 	err := j.Parse(template)
@@ -58,6 +63,10 @@ func SetNestedField(obj interface{}, value interface{}, path string) error {
 		return errors.New("setting value to nil object")
 	}
 
+	if path == "" {
+		return errors.New("setting value to empty path")
+	}
+
 	var parent interface{}
 	var err error
 	found := false
@@ -77,7 +86,7 @@ func SetNestedField(obj interface{}, value interface{}, path string) error {
 		slice = false
 
 		// special processing for slice filter
-		// only support format: field[?(@.key=\"value\"")]
+		// only support format: field[?(@.key==\"value\"")]
 		if strings.ContainsAny(lastField, "]") {
 			// get full field and remove the "." before key
 			tmp := lastField

--- a/utils/unstructured.go
+++ b/utils/unstructured.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package utils
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -31,14 +32,14 @@ var (
 )
 
 // NestedField returns the value of a nested field in the given object based on the given JSON-Path.
-func NestedField(obj *unstructured.Unstructured, name, path string) (interface{}, bool, error) {
+func NestedField(obj interface{}, name, path string) (interface{}, bool, error) {
 	j := jsonpath.New(name).AllowMissingKeys(true)
 	template := fmt.Sprintf("{%s}", path)
 	err := j.Parse(template)
 	if err != nil {
 		return nil, false, err
 	}
-	results, err := j.FindResults(obj.UnstructuredContent())
+	results, err := j.FindResults(obj)
 	if err != nil {
 		return nil, false, err
 	}
@@ -53,26 +54,84 @@ func NestedField(obj *unstructured.Unstructured, name, path string) (interface{}
 
 func SetNestedField(obj interface{}, value interface{}, path string) error {
 
-	loc := strings.LastIndex(path, ".")
-	uppath := path[:loc]
-	lastfield := path[loc+1:]
+	if obj == nil {
+		return errors.New("setting value to nil object")
+	}
 
-	j := jsonpath.New(lastfield).AllowMissingKeys(true)
-	template := fmt.Sprintf("{%s}", uppath)
-	err := j.Parse(template)
-	if err != nil {
-		return err
+	var parent interface{}
+	var err error
+	found := false
+	slice := false
+
+	// remove all spaces because it is not allowed as path name
+	path = strings.ReplaceAll(path, " ", "")
+
+	loc := len(path)
+	lastField := ""
+	upperPath := ""
+
+	for loc > 0 {
+		loc = strings.LastIndex(path, ".")
+		lastField = path[loc+1:]
+		upperPath = path[:loc]
+		slice = false
+
+		// special processing for slice filter
+		// only support format: field[?(@.key=\"value\"")]
+		if strings.ContainsAny(lastField, "]") {
+			// get full field and remove the "." before key
+			tmp := lastField
+			path = upperPath
+			loc = strings.LastIndex(path, ".")
+			lastField = path[loc+1:] + tmp
+			upperPath = path[:loc]
+
+			var k, v string
+			lastField = strings.ReplaceAll(lastField, "[?(@", " ")
+			lastField = strings.ReplaceAll(lastField, "==", " ")
+			lastField = strings.ReplaceAll(lastField, "\"", "")
+			lastField = strings.ReplaceAll(lastField, ")]", " ")
+			n, err := fmt.Sscanf(lastField, "%s %s %s", &lastField, &k, &v)
+			if n != 3 || err != nil {
+				if err == nil {
+					err = fmt.Errorf("failed to parse slice filter, only got %d, need 3", n)
+				}
+				return err
+			}
+			value.(map[string]interface{})[k] = v
+			value = []map[string]interface{}{value.(map[string]interface{})}
+			slice = true
+		}
+
+		parent, found, err = NestedField(obj, lastField, upperPath)
+
+		if err != nil {
+			return err
+		}
+
+		if found {
+			break
+		}
+
+		// full path is not located, try upper path
+
+		value = map[string]interface{}{
+			lastField: value,
+		}
+		path = upperPath
 	}
-	results, err := j.FindResults(obj)
-	if err != nil {
-		return err
+
+	if found {
+		if slice {
+			s := parent.(map[string]interface{})[lastField].([]map[string]interface{})
+			s = append(s, value.([]map[string]interface{})...)
+			parent.(map[string]interface{})[lastField] = s
+		} else {
+			parent.(map[string]interface{})[lastField] = value
+		}
+	} else {
+		obj.(map[string]interface{})[lastField] = value.(map[string]interface{})[lastField]
 	}
-	if len(results) == 0 || len(results[0]) == 0 {
-		return nil
-	}
-	// The input path refers to a unique field, we can assume to have only one result or none.
-	parent := results[0][0].Interface().(map[string]interface{})
-	parent[lastfield] = value
 
 	return nil
 }

--- a/utils/unstructured.go
+++ b/utils/unstructured.go
@@ -32,8 +32,8 @@ var (
 )
 
 // NestedField returns the value of a nested field in the given object based on the given JSON-Path.
-func NestedField(obj interface{}, name, path string) (interface{}, bool, error) {
-	j := jsonpath.New(name).AllowMissingKeys(true)
+func NestedField(obj interface{}, path string) (interface{}, bool, error) {
+	j := jsonpath.New(path).AllowMissingKeys(true)
 	template := fmt.Sprintf("{%s}", path)
 	err := j.Parse(template)
 	if err != nil {
@@ -103,7 +103,7 @@ func SetNestedField(obj interface{}, value interface{}, path string) error {
 			slice = true
 		}
 
-		parent, found, err = NestedField(obj, lastField, upperPath)
+		parent, found, err = NestedField(obj, upperPath)
 
 		if err != nil {
 			return err
@@ -140,7 +140,7 @@ func PrepareRawExtensionFromUnstructured(obj *unstructured.Unstructured, objPath
 
 	fields := strings.Split(objPath, ".")
 	lastField := fields[len(fields)-1]
-	valueInObj, found, err := NestedField(obj.Object, lastField, objPath)
+	valueInObj, found, err := NestedField(obj.Object, objPath)
 
 	valueMap := make(map[string]interface{})
 	valueMap[lastField] = valueInObj

--- a/utils/unstructured.go
+++ b/utils/unstructured.go
@@ -140,7 +140,7 @@ func PrepareRawExtensionFromUnstructured(obj *unstructured.Unstructured, objPath
 
 	fields := strings.Split(objPath, ".")
 	lastField := fields[len(fields)-1]
-	valueInObj, found, err := NestedField(obj, lastField, objPath)
+	valueInObj, found, err := NestedField(obj.Object, lastField, objPath)
 
 	valueMap := make(map[string]interface{})
 	valueMap[lastField] = valueInObj


### PR DESCRIPTION
This issue is part of [OM-97052]: ORM v2 resize action.

All tasks in issue are completed with this PR. 

Event recording needs to be done in kubeturbo outside orm, coz it must be done after Updating the owner resource. 

I saw kubeturbo already initialized its own event recorder, you can pass it to kuberentes.Toolbox during initialization or use it directly (pass nil to toolbox).

Example of doing updating is in `compareAndEnforce` function in `controllers/advicemapping_controller.go` You have your own way to construct the `valueFromAdvisor`, ignore that part.

```
		if m.Owner.Namespace == "" {
			m.Owner.Namespace = am.Namespace
		}
		obj, err = kubernetes.Toolbox.GetResourceWithObjectReference(m.Owner.ObjectReference)
		if err != nil {
			acLog.Error(err, "finding true owner", "owner", m.Owner)
			continue
		}

		valueInOwner, found, err := ormutils.NestedField(obj.Object, m.Owner.Path)
		if err != nil {
			acLog.Error(err, "finding path in owner", "path", m.Owner.Path)
			continue
		}
		var valueFromAdvisor interface{}
		vMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(m.Value)
		if err != nil {
			acLog.Error(err, "converting value", "value", m.Value)
			continue
		}
		for _, v := range vMap {
			valueFromAdvisor = v
			break
		}

		if !reflect.DeepEqual(valueInOwner, valueFromAdvisor) {
			ormutils.SetNestedField(obj.Object, valueFromAdvisor, m.Owner.Path)

			err = kubernetes.Toolbox.UpdateResourceWithGVK(obj.GroupVersionKind(), obj)
			if err != nil {
				acLog.Error(err, "updating true owner", "owner", m.Owner)
				continue
			}
			if !found {
				kubernetes.Toolbox.RecordEventf(obj, "Normal", "Updated", "Updated %s as advised by %s/%s and completed omitted path", m.Owner.Path, am.GetNamespace(), am.GetName())
			} else {
				kubernetes.Toolbox.RecordEventf(obj, "Normal", "Updated", "Updated %s as advised by %s/%s", m.Owner.Path, am.GetNamespace(), am.GetName())
			}
		}
```